### PR TITLE
feat(cli): add compilation output type

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use std::path::PathBuf;
 
 #[derive(clap::Parser, Debug)]
@@ -7,7 +8,35 @@ pub(crate) struct Args {
     pub command: Commands,
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub(crate) enum CompilationType {
+    Ast,
+    Mips,
+}
+
+impl Default for CompilationType {
+    fn default() -> Self {
+        Self::Mips
+    }
+}
+
+impl std::fmt::Display for CompilationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompilationType::Ast => write!(f, "ast"),
+            CompilationType::Mips => write!(f, "mips"),
+        }
+    }
+}
+
 #[derive(clap::Subcommand, Debug)]
 pub(crate) enum Commands {
-    Compile { file: PathBuf },
+    /// Invoke the ayysee compiler
+    Compile {
+        /// The file to compile
+        file: PathBuf,
+        /// Select what type of output to generate
+        #[clap(short, long, value_enum, default_value_t = CompilationType::default())]
+        output: CompilationType,
+    },
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,16 +12,20 @@ async fn main() -> Result<()> {
 
     let args = commands::Args::parse();
     match args.command {
-        Commands::Compile { file } => {
+        Commands::Compile { file, output } => {
             let file_contents = tokio::fs::read_to_string(file).await.unwrap();
 
             let parser = ProgramParser::new();
 
             let parsed = parser.parse(&file_contents).unwrap();
 
-            let compiled = generate_program(parsed)?;
-
-            println!("{}", compiled);
+            match output {
+                commands::CompilationType::Ast => println!("{:#?}", parsed),
+                commands::CompilationType::Mips => {
+                    let compiled = generate_program(parsed)?;
+                    println!("{}", compiled);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Usage\: add the `--output` or `-o` flag to a compiler invocation to allow users to select what type of output. The default remains to compile to Stationeers MIPS, but now there is the ability to specify if you only want an AST. In the future this could be used to display any intermediate representation.