### PR TITLE
feat(web): display compilation error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,12 @@
         async function click_compile() {
             let code = document.getElementById("code").value;
             let output = document.getElementById("code-output");
-            output.value = compile_code(code);
+            try {
+                output.value = compile_code(code);
+            } catch (e) {
+                console.error(e);
+                output.value = e;
+            }
         }
 
         init().then(() => {


### PR DESCRIPTION
Errors during compilation will be shown in the output box. There is no indication that the text is an error, but it should hopefully be clear from the look of the output. Errors are still logged to the console as before.